### PR TITLE
注文登録の実装

### DIFF
--- a/src/main/java/jp/co/esm/bento/web/controller/MasterController.java
+++ b/src/main/java/jp/co/esm/bento/web/controller/MasterController.java
@@ -30,7 +30,6 @@ public class MasterController {
   @GetMapping(value = "/load")
   public String setData()
   {
-    log.info("setData");
     masterService.loadData();
     return "OK.";
   }

--- a/src/main/java/jp/co/esm/bento/web/controller/OrderController.java
+++ b/src/main/java/jp/co/esm/bento/web/controller/OrderController.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,6 +38,22 @@ public class OrderController {
     log.info("getOrders");
     log.info("week: {}", week);
     log.info("user: {}", user);
+    return orderService.getOrders(user.getUserId(), week);
+  }
+
+  /**
+   * 指定のユーザと週に該当する注文内容を登録または更新します。
+   * 
+   * @param week 週の日付（月曜日始まり）
+   * @param orders 注文内容
+   * @param user ユーザ
+   * @return 注文内容
+   */
+  @PostMapping("/{week}")
+  public List<Order> updateOrders(@PathVariable LocalDate week, @RequestBody List<Order> orders,@AuthenticationPrincipal GoogleUser user) {
+    // 指定の内容でDatastoreに反映
+    orderService.createOrUpdateOrders(orders, user.getUserId(), week);
+    // 登録結果を返す
     return orderService.getOrders(user.getUserId(), week);
   }
 }

--- a/src/main/java/jp/co/esm/bento/web/model/Order.java
+++ b/src/main/java/jp/co/esm/bento/web/model/Order.java
@@ -10,7 +10,6 @@ import lombok.Data;
 
 /**
  * Orderエンティティの内容を保有するモデルクラスです。
- *
  */
 @Data
 public class Order {

--- a/src/main/java/jp/co/esm/bento/web/repository/OrderRepository.java
+++ b/src/main/java/jp/co/esm/bento/web/repository/OrderRepository.java
@@ -80,12 +80,12 @@ public class OrderRepository implements DatastoreRepository<Order> {
   
   /**
    * 指定の条件で注文を最大5件取得します。
+   * 
    * @param userId ユーザID
    * @param week 週の始めの日付
    * @return 取得した結果
    */
-  public List<Order> listByUserIdAndWeek(String userId, LocalDate week)
-  {
+  public List<Order> listByUserIdAndWeek(String userId, LocalDate week) {
     // 週の初めの日付と終わりの日付を取得
     Date fromDate = DateUtil.localDateToDate(week);
     Date toDate = DateUtil.localDateToDate(week.plusDays(4));
@@ -98,6 +98,29 @@ public class OrderRepository implements DatastoreRepository<Order> {
     PreparedQuery preparedQuery = datastore.prepare(query);
     QueryResultIterator<Entity> entities = preparedQuery.asQueryResultIterator();
     return entitiesToModels(entities);
+  }
+  
+  /**
+   * 指定のユーザIDと日付を持つエンティティを取得します。
+   * 
+   * @param userId ユーザID
+   * @param date 注文日
+   * @return 取得した結果
+   */
+  public Order readByUserIdAndDate(String userId, LocalDate date) {
+    Filter userFilter = new FilterPredicate(Order.USER_ID, FilterOperator.EQUAL, userId);
+    Filter dateFilter = new FilterPredicate(Order.DATE, FilterOperator.EQUAL, DateUtil.localDateToDate(date));
+    Query query = new Query(KIND)
+        .setFilter(CompositeFilterOperator.and(userFilter, dateFilter));
+    PreparedQuery preparedQuery = datastore.prepare(query);
+    QueryResultIterator<Entity> entities = preparedQuery.asQueryResultIterator();
+    List<Order> orders = entitiesToModels(entities);
+    if (orders.isEmpty()) {
+      // 注文なし
+      return null;
+    }
+    // TODO 2件以上はないはず
+    return orders.get(0);
   }
 
   /**

--- a/src/main/java/jp/co/esm/bento/web/service/MasterService.java
+++ b/src/main/java/jp/co/esm/bento/web/service/MasterService.java
@@ -35,7 +35,6 @@ public class MasterService {
     Master master = new Master();
     master.setOkazu(okazuRepository.list());
     master.setGohan(gohanRepository.list());
-    log.info("master :{}", master);
     return master;
   }
   

--- a/src/main/java/jp/co/esm/bento/web/service/OrderService.java
+++ b/src/main/java/jp/co/esm/bento/web/service/OrderService.java
@@ -8,16 +8,27 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
+
 import jp.co.esm.bento.web.model.Order;
 import jp.co.esm.bento.web.repository.OrderRepository;
 import jp.co.esm.bento.web.util.DateUtil;
+import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Orderのサービスクラスです。
+ */
 @Service
 public class OrderService {
 
   @Autowired
   private OrderRepository orderRepository;
 
+  @Autowired
+  private DatastoreService datastore;
+  
   /**
    * 指定のユーザの指定の週の5日分の注文内容を取得します。
    * 
@@ -63,5 +74,68 @@ public class OrderService {
     // 日付でソート
     results.sort(Comparator.comparing(Order::getDate));
     return results;
+  }
+
+  /**
+   * 指定の内容で注文内容をOrderエンティティに登録または更新します。
+   * 
+   * @param orders 注文内容（最大5件）
+   * @param userId ユーザID
+   * @param week 週の初めの日付
+   */
+  public void createOrUpdateOrders(List<Order> orders, String userId, LocalDate week) {
+    TransactionOptions options = TransactionOptions.Builder.withXG(true);
+    Transaction transaction = datastore.beginTransaction(options);
+    try {
+      
+      for (Order order : orders) {
+        // 注文なしかどうか
+        boolean noOrder = isNoOrder(order);
+        // 対象の注文が登録済みか
+        Order result = orderRepository.readByUserIdAndDate(userId, order.getDate());
+        if (result == null) {
+          // 注文なしは登録しない
+          if (noOrder) continue;
+          order.setUserId(userId);
+          orderRepository.create(order);
+        } else if (noOrder) {
+          // 登録済み->注文なしのため削除
+          orderRepository.delete(result.getId());
+        } else {
+          // 注文内容を更新
+          result.setOkazu(order.getOkazu());
+          result.setGohan(order.getGohan());
+          result.setMiso(order.getMiso());
+          result.setPrice(order.getPrice());
+          orderRepository.update(result);
+        }
+      }
+      transaction.commit();
+
+    } finally {
+      if (transaction.isActive()) {
+        transaction.rollback();
+      }
+    }
+  }
+  
+  /**
+   * 対象の注文が空かどうかチェックします。
+   * @param order 注文内容
+   * @return 注文なしの場合はtrue、ありの場合はfalse
+   */
+  private boolean isNoOrder(Order order) {
+    // おかずチェック
+    if (order.getOkazu() != null &&
+        !order.getOkazu().isEmpty()) {
+        return false;
+    }
+    // ごはんチェック
+    if (order.getGohan() != null &&
+        !order.getGohan().isEmpty()) {
+      return false;
+    }
+    // おかず・ごはんなしで味噌汁ありはないのでチェックしない
+    return true;
   }
 }

--- a/src/test/java/jp/co/esm/bento/web/repository/GohanRepositoryTest.java
+++ b/src/test/java/jp/co/esm/bento/web/repository/GohanRepositoryTest.java
@@ -52,14 +52,14 @@ public class GohanRepositoryTest {
     // 1件目データ投入
     Gohan gohan = new Gohan();
     gohan.setLabel("白米");
-    gohan.setPrice(new Long(154));
+    gohan.setPrice(154L);
     gohan.setValue("hakumai");
     testDatas.add(repository.create(gohan));
 
     // 2件目データ投入
     gohan = new Gohan();
     gohan.setLabel("日替わり健康米");
-    gohan.setPrice(new Long(185));
+    gohan.setPrice(185L);
     gohan.setValue("higawari");
     testDatas.add(repository.create(gohan));
   }
@@ -74,7 +74,7 @@ public class GohanRepositoryTest {
   public void testCreate() {
     Gohan gohan = new Gohan();
     gohan.setLabel("たきこみごはん");
-    gohan.setPrice(new Long(108));
+    gohan.setPrice(108L);
     gohan.setValue("takikomi");
     Entity actual = repository.create(gohan);
     
@@ -101,7 +101,7 @@ public class GohanRepositoryTest {
     Gohan gohan = repository.read(entity.getKey().getId());
     
     gohan.setLabel("違うラベル名");
-    gohan.setPrice(new Long(433));
+    gohan.setPrice(433L);
     repository.update(gohan);
 
     // 更新後のエンティティを取得して検証

--- a/src/test/java/jp/co/esm/bento/web/repository/OkazuRepositoryTest.java
+++ b/src/test/java/jp/co/esm/bento/web/repository/OkazuRepositoryTest.java
@@ -53,23 +53,23 @@ public class OkazuRepositoryTest {
     // 1件目データ投入
     Okazu okazu = new Okazu();
     okazu.setLabel("愛");
-    okazu.setPrice(new Long(360));
+    okazu.setPrice(360L);
     okazu.setValue("ai");
     testDatas.add(repository.create(okazu));
 
     // 2件目データ投入
     okazu = new Okazu();
     okazu.setLabel("ゆうき");
-    okazu.setPrice(new Long(411));
+    okazu.setPrice(411L);
     okazu.setValue("yuuki");
     testDatas.add(repository.create(okazu));
 
     // 3件目データ投入（曜日あり）
     okazu = new Okazu();
     okazu.setLabel("オムライス");
-    okazu.setPrice(new Long(450));
+    okazu.setPrice(450L);
     okazu.setValue("higawari4");
-    okazu.setDayofweek(new Long(4));
+    okazu.setDayofweek(4L);
     testDatas.add(repository.create(okazu));
   }
 
@@ -83,7 +83,7 @@ public class OkazuRepositoryTest {
   public void testCreate() {
     Okazu okazu = new Okazu();
     okazu.setLabel("日替わり弁当");
-    okazu.setPrice(new Long(380));
+    okazu.setPrice(380L);
     okazu.setValue("higawari0");
     Entity actual = repository.create(okazu);
     


### PR DESCRIPTION
・登録（POST）のAPI追加
・Orderエンティティをユニークキー相当で取得するメソッド追加
・１トランザクションで最大5件登録する機能とした
・クライアント側にて注文受付日と〆日について実装
・テストクラスの警告（ボクシング）修正
・コメント調整
・不要になったログ出力削除