### PR TITLE
GoogleカレンダーAPIを利用して祝日の情報を取得

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,11 @@ dependencies {
   compile 'com.google.appengine:appengine-api-1.0-sdk:+'
   compileOnly 'org.projectlombok:lombok'
   compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
-  compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.10"
+  compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.10'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.8.8.1'
   testCompile 'org.springframework.boot:spring-boot-starter-test'
-  testCompile  "com.google.appengine:appengine-api-stubs:+"
-  testCompile  "com.google.appengine:appengine-testing:+"
+  testCompile  'com.google.appengine:appengine-api-stubs:+'
+  testCompile  'com.google.appengine:appengine-testing:+'
 }
 
 node {

--- a/src/main/java/jp/co/esm/bento/web/controller/OrderController.java
+++ b/src/main/java/jp/co/esm/bento/web/controller/OrderController.java
@@ -3,8 +3,11 @@ package jp.co.esm.bento.web.controller;
 import java.time.LocalDate;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 import jp.co.esm.bento.web.model.GoogleUser;
 import jp.co.esm.bento.web.model.Order;
+import jp.co.esm.bento.web.service.CalendarService;
 import jp.co.esm.bento.web.service.OrderService;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,6 +28,10 @@ public class OrderController {
   // 注文サービス
   @Autowired
   private OrderService orderService;
+  
+  // googleカレンダーサービス
+  @Autowired
+  private CalendarService calendarService;
 
   /**
    * 指定のユーザと週に該当する注文内容を取得します。
@@ -34,11 +41,15 @@ public class OrderController {
    * @return 注文内容
    */
   @GetMapping("/{week}")
-  public List<Order> getOrders(@PathVariable LocalDate week, @AuthenticationPrincipal GoogleUser user) {
+  public List<Order> getOrders(@PathVariable LocalDate week, @AuthenticationPrincipal GoogleUser user, HttpServletRequest request) {
     log.info("getOrders");
     log.info("week: {}", week);
     log.info("user: {}", user);
-    return orderService.getOrders(user.getUserId(), week);
+    // 指定の注文情報を取得
+    List<Order> orders = orderService.getOrders(user.getUserId(), week);
+    // 休日情報を設定
+    setHoliday(orders, request.getRequestURL().toString());
+    return orders;
   }
 
   /**
@@ -55,5 +66,21 @@ public class OrderController {
     orderService.createOrUpdateOrders(orders, user.getUserId(), week);
     // 登録結果を返す
     return orderService.getOrders(user.getUserId(), week);
+  }
+
+  /**
+   * 指定の注文内容の注文日に対して休日かどうかを設定します。
+   * 
+   * @param orders 注文内容
+   * @param requestUrl リクエストURL(認証で使用）
+   */
+  private void setHoliday(List<Order> orders, String requestUrl) {
+    // Googleの祝日カレンダーより指定範囲の祝日を取得
+    List<LocalDate> holidays = calendarService.GetHolidays(orders.get(0).getDate(), orders.get(4).getDate(), requestUrl);
+    if (holidays == null || holidays.isEmpty()) {
+      return;
+    }
+    // 注文日に祝日があれば設定
+    orders.stream().filter(o -> holidays.contains(o.getDate())).forEach(o -> o.setHoliday(true));
   }
 }

--- a/src/main/java/jp/co/esm/bento/web/model/CalendarEvent.java
+++ b/src/main/java/jp/co/esm/bento/web/model/CalendarEvent.java
@@ -1,0 +1,35 @@
+package jp.co.esm.bento.web.model;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+/**
+ * Google Calendar API が戻すEventの内容を格納するモデルです。
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CalendarEvent {
+
+  // Key="Item"の内容
+  private List<CalendarItem> items;
+  
+  /**
+   * CalendarのItemsのうち、dateのみを返します。
+   * 
+   * @return 日付を格納したリスト
+   */
+  public List<LocalDate> getDateList() {
+    if (items == null || items.isEmpty()) {
+      return new ArrayList<LocalDate>();
+    }
+    
+    return items.stream().map(i -> i.getData()).collect(Collectors.toList());
+  }
+}
+

--- a/src/main/java/jp/co/esm/bento/web/model/CalendarItem.java
+++ b/src/main/java/jp/co/esm/bento/web/model/CalendarItem.java
@@ -1,0 +1,32 @@
+package jp.co.esm.bento.web.model;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import jp.co.esm.bento.web.util.DateUtil;
+import lombok.Data;
+
+/**
+ * Google Calendar API が戻すレスポンスのうち、Key="Item"の内容を格納するモデルです。 
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CalendarItem {
+  
+  // Key="start"のJson内容
+  private CalendarStartDate start;
+
+  // Key="summary"の値
+  private String summary;
+  
+  /**
+   * 祝日の日付を返します。
+   * 
+   * @return 祝日
+   */
+  public LocalDate getData() {
+    return DateUtil.stringToLocalDate(start.getDate());
+  }
+}
+

--- a/src/main/java/jp/co/esm/bento/web/model/CalendarStartDate.java
+++ b/src/main/java/jp/co/esm/bento/web/model/CalendarStartDate.java
@@ -1,0 +1,16 @@
+package jp.co.esm.bento.web.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+/**
+ * Google Calendar API が戻すレスポンスのうち、Key="start"のJson内容を格納するモデルです。
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CalendarStartDate {
+  
+  // Key="date"の値
+  private String date;
+}

--- a/src/main/java/jp/co/esm/bento/web/model/Order.java
+++ b/src/main/java/jp/co/esm/bento/web/model/Order.java
@@ -35,6 +35,9 @@ public class Order {
   // 値段
   private Long price;
   
+  // 祝日かどうか
+  private Boolean holiday;
+  
   // プロパティ名：ID
   public static final String ID = "id";
   // プロパティ名：date
@@ -49,6 +52,8 @@ public class Order {
   public static final String USER_ID = "userId";
   // プロパティ名：price
   public static final String PRICE = "price";
+  // プロパティ名：holiday
+  public static final String HOLIDAY = "holiday";
   
   /**
    * 指定のエンティティの内容をモデルに設定します。
@@ -63,6 +68,7 @@ public class Order {
     this.okazu = (String)entity.getProperty(OKAZU);
     this.userId = (String)entity.getProperty(USER_ID);
     this.price = (Long)entity.getProperty(PRICE);
+    this.holiday = Boolean.FALSE;
   }
   
   /**

--- a/src/main/java/jp/co/esm/bento/web/service/CalendarService.java
+++ b/src/main/java/jp/co/esm/bento/web/service/CalendarService.java
@@ -1,0 +1,102 @@
+package jp.co.esm.bento.web.service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jp.co.esm.bento.web.model.CalendarEvent;
+
+/**
+ * Googleカレンダーのサービスクラスです。
+ */
+@Service
+public class CalendarService {
+
+  // GoogleカレンダーURL
+  @Value("${google.api.calendar.url}")
+  private String calendarUrl;
+
+  // 休日カレンダーID
+  @Value("${google.api.calendar.id}")
+  private String calendarId;
+
+  // APIキー
+  @Value("${google.api.calendar.key}")
+  private String apiKey;
+
+  // Json
+  private static ObjectMapper objectMapper = new ObjectMapper();
+  
+  /**
+   * 指定範囲の国民の休日をGoogleカレンダーより取得します。
+   *
+   * @param from 指定範囲from
+   * @param to　指定範囲to
+   * @param requestUrl リクエストURL
+   * @return 休日が格納されたリスト（ない場合は空）
+   */
+  public List<LocalDate> GetHolidays(LocalDate from, LocalDate to, String requestUrl) {
+    // 休日取得クエリー
+    String timeMin = from.format(DateTimeFormatter.ofPattern("yyyy-M-d")) + "T00:00:00Z";
+    String timeMax = to.format(DateTimeFormatter.ofPattern("yyyy-M-d")) + "T23:59:59Z";
+    String query = String.format("key=%s&timeMin=%s&timeMax=%s&maxResults=%d&orderBy=startTime&singleEvents=true", apiKey, timeMin, timeMax, 30);
+
+    HttpURLConnection con = null;
+    InputStream in = null;
+    BufferedReader reader = null;
+    try {
+      // 祝日カレンダーアクセス
+      URL url = new URL(calendarUrl + calendarId + "/events?" + query);
+      con = (HttpURLConnection)url.openConnection();
+      // HTTPリファラー設定(アクセスサイトを制限しているため）
+      con.setRequestProperty("Referer", requestUrl);
+      con.connect();
+      if (con.getResponseCode() == HttpURLConnection.HTTP_OK) {
+        // レスポンス取得
+        in = con.getInputStream();
+        reader = new BufferedReader(new InputStreamReader(in));
+
+        StringBuilder output = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          output.append(line);
+        }
+        // Jsonデータより祝日のみ取得
+        CalendarEvent event = objectMapper.readValue(output.toString(), CalendarEvent.class);
+        return event.getDateList();
+      }
+
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    } finally {
+      if (con != null) {
+        con.disconnect();
+      }
+      try {
+        if (in != null) {
+          in.close();
+        }
+        if (reader != null) {
+          reader.close();
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/jp/co/esm/bento/web/service/OrderService.java
+++ b/src/main/java/jp/co/esm/bento/web/service/OrderService.java
@@ -15,7 +15,6 @@ import com.google.appengine.api.datastore.TransactionOptions;
 import jp.co.esm.bento.web.model.Order;
 import jp.co.esm.bento.web.repository.OrderRepository;
 import jp.co.esm.bento.web.util.DateUtil;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Orderのサービスクラスです。
@@ -69,12 +68,14 @@ public class OrderService {
       order.setOkazu("");
       order.setMiso(false);
       order.setPrice(0L);
+      order.setHoliday(false);
       results.add(order);
     }
     // 日付でソート
     results.sort(Comparator.comparing(Order::getDate));
     return results;
   }
+  
 
   /**
    * 指定の内容で注文内容をOrderエンティティに登録または更新します。

--- a/src/main/java/jp/co/esm/bento/web/util/DateUtil.java
+++ b/src/main/java/jp/co/esm/bento/web/util/DateUtil.java
@@ -2,6 +2,7 @@ package jp.co.esm.bento.web.util;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -12,6 +13,8 @@ import java.util.stream.IntStream;
  */
 public class DateUtil {
 
+  static final private String DEFAULT_DATE_FORMAT = "yyyy-MM-dd";
+  
   /**
    * Date型からLocalDate型へ変換します。
    * @param target Date型の日付
@@ -22,6 +25,30 @@ public class DateUtil {
       return null;
     }
     return target.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+  }
+  
+  /**
+   * yyyy-MM-ddでフォーマットされた日付をLocalDate型へ変換します。
+   * 
+   * @param target yyyy-MM-ddでフォーマットされた日付
+   * @return LocalDate型の日付（変換失敗した場合はnull）
+   */
+  public static LocalDate stringToLocalDate(String target) {
+    return stringToLocalDate(target, DEFAULT_DATE_FORMAT);    
+  }
+  
+  /**
+   * 指定の書式の文字列型日付をLocalDate型へ変換します。
+   * 
+   * @param target　フォーマットされた日付
+   * @param format 書式
+   * @return LocalDate型の日付（変換失敗した場合はnull）
+   */
+  public static LocalDate stringToLocalDate(String target, String format) {
+    if (target == null || target.isEmpty()) {
+      return null;
+    }
+    return LocalDate.parse(target, DateTimeFormatter.ofPattern(format)); 
   }
   
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ google:
   auth:
     client-id: 599875423654-67v0atig5nn91to63c2d4a7lmpgi55ns.apps.googleusercontent.com
     hosted-domain: esm.co.jp
+  api:
+    calendar:
+      url: https://www.googleapis.com/calendar/v3/calendars/
+      id: japanese__ja@holiday.calendar.google.com
+      key: 
 spring:
   jackson:
     serialization:

--- a/src/test/java/jp/co/esm/bento/web/service/CalendarServiceTest.java
+++ b/src/test/java/jp/co/esm/bento/web/service/CalendarServiceTest.java
@@ -1,0 +1,55 @@
+package jp.co.esm.bento.web.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class CalendarServiceTest {
+
+  @Autowired
+  private CalendarService service;
+  
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void testGetHolidays_休日なし() {
+    LocalDate from = LocalDate.of(2018, 3, 5);
+    LocalDate to = LocalDate.of(2018, 3, 9);
+    List<LocalDate> actual = service.GetHolidays(from, to, "http://localhost:8080");
+    
+    assertThat(actual, is(notNullValue()));
+    assertThat(actual.size(), is(0));
+  }
+
+  @Test
+  public void testGetHolidays_休日あり() {
+    LocalDate from = LocalDate.of(2018, 4, 30);
+    LocalDate to = LocalDate.of(2018, 5, 4);
+    List<LocalDate> actual = service.GetHolidays(from, to, "http://localhost:8080");
+    assertThat(actual, is(notNullValue()));
+    assertThat(actual.size(), is(3));
+    
+    assertThat(actual.get(0), is(LocalDate.of(2018, 4, 30)));
+    assertThat(actual.get(1), is(LocalDate.of(2018, 5, 3)));
+    assertThat(actual.get(2), is(LocalDate.of(2018, 5, 4)));
+  }
+}

--- a/src/test/java/jp/co/esm/bento/web/service/OrderServiceTest.java
+++ b/src/test/java/jp/co/esm/bento/web/service/OrderServiceTest.java
@@ -61,6 +61,7 @@ public class OrderServiceTest {
       assertThat(actual.get(i).getOkazu(), is(""));
       assertThat(actual.get(i).getMiso(), is(false));
       assertThat(actual.get(i).getPrice(), is(new Long(0)));
+      assertThat(actual.get(i).getHoliday(), is(false));
     });
   }
 
@@ -86,6 +87,7 @@ public class OrderServiceTest {
       assertThat(actual.get(i).getOkazu(), is(""));
       assertThat(actual.get(i).getMiso(), is(false));
       assertThat(actual.get(i).getPrice(), is(new Long(0)));
+      assertThat(actual.get(i).getHoliday(), is(false));
     });
     
     // 月、水、木はダミーデータであること
@@ -128,9 +130,10 @@ public class OrderServiceTest {
       order.setMiso(true);
       order.setPrice(new Long(400+i));
       order.setUserId(userId);
+      order.setHoliday(false);
       results.add(order);
     }
     return results;
   }
-  
+ 
 }

--- a/vue/src/components/Order.vue
+++ b/vue/src/components/Order.vue
@@ -20,15 +20,15 @@
               v-for="order in orders"
               :key="order.date">
               <td>{{ order.id | status }}</td>
-              <td>{{ order.date }}</td>
-              <td>{{ order.date | dayofweek }}</td>
+              <td v-bind:class="[order.holiday? 'holiday' : '']">{{ order.date }}</td>
+              <td v-bind:class="[order.holiday? 'holiday' : '']">{{ order.date | dayofweek }}</td>
               <td>
                 <q-select
                   v-model="order.okazu"
                   inverted
                   color="light-blue"
                   separator
-                  :disabled="closed"
+                  :disable="closed || order.holiday"
                   :options="filteredOkazu(order.date)"
                   @change="validate(order)"
                 />
@@ -39,7 +39,7 @@
                   inverted
                   color="cyan"
                   separator
-                  :disable="closed"
+                  :disable="closed || order.holiday"
                   :options="options.gohan"
                   @change="validate(order)"
                 />
@@ -48,7 +48,7 @@
                 <q-toggle
                   v-model="order.miso"
                   color="light-green"
-                  :disable="closed"
+                  :disable="closed || order.holiday"
                   :click="validateMiso(order)"
                 />
               </td>
@@ -223,11 +223,11 @@ export default {
   mounted () {
     let today = moment()
     // 翌週の月曜の日付
-    this.week = today.add(7, 'days').day(1).format('YYYY-MM-DD')
+    this.week = today.clone().add(7, 'days').day(1).format('YYYY-MM-DD')
     // 0は日曜日をさすため、日曜日から翌週の受付開始となる
     // 〆日判定（金曜日15時まで）
-    let closingDate = today.day(5).set('hour', 15).set('minute', 0).set('second', 0)
-    this.closed = (today - closingDate > 0)
+    let closingDate = today.clone().day(5).set('hour', 15).set('minute', 0).set('second', 0)
+    this.closed = today.diff(closingDate) > 0
 
     // データ取得
     this.getOrders(this.week)
@@ -285,4 +285,8 @@ export default {
 </script>
 
 <style lang="css">
+  .holiday {
+    color: 'red';
+    font-weight: bold;
+  }
 </style>


### PR DESCRIPTION
注文画面で祝日の日は注文不可とした
moment() の破壊的メソッドの対応（バグ）

※APIキーはわざと削除してあります。お手数ですが、実行する際はGCPコンソールにてAPIキーを確認して各自で設定お願いします。