### PR TITLE
401エラー時はログアウトしてログイン画面へ遷移させる

### DIFF
--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -52,6 +52,15 @@ export default {
     if (isSignedIn) {
       this.onSignedIn(await auth.getCurrentUser())
     }
+    this.$http.interceptors.response.use(
+      response => {
+      },
+      error => {
+        if (error.response.status === 401) {
+          this.signOut()
+        }
+      }
+    )
   }
 }
 </script>


### PR DESCRIPTION
しばらく使ってないとサーバー側だけログアウトしてしまいAPIコールがエラーになるので、401エラー発生したらログアウトするようにしました。